### PR TITLE
Make libdir a variable in Makefile

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -1,9 +1,10 @@
 INSTALL = install
 DESTDIR ?=
+LIBDIR ?= /usr/lib
 
 #IRSSI_INCLUDE:=/home/phh/irssi-0.8.16-rc1.phh/
 IRSSI_INCLUDE:=/usr/include/irssi/
-IRSSI_LIB?=$(DESTDIR)/usr/lib/irssi
+IRSSI_LIB?=$(DESTDIR)/$(LIBDIR)/irssi
 IRSSI_CFLAGS+=-I$(IRSSI_INCLUDE)/src/
 IRSSI_CFLAGS+=-I$(IRSSI_INCLUDE)/src/core/
 IRSSI_CFLAGS+=-I$(IRSSI_INCLUDE)/src/fe-common/


### PR DESCRIPTION
This makes the hardcoded path `/usr/lib` a variable in the Makefile to
allow for users/downstream maintainers to specify an alternate location
(such as `/usr/lib64`) while keeping a default of `/usr/lib`.