### PR TITLE
If SYSTEM_QUASSELC set, build against system-wide libquasselc

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -17,21 +17,34 @@ OBJECTS+=quassel-net.o quassel-msgs.o quassel-cmds.o
 OBJECTS+=irssi/network-openssl.o
 OBJECTS+=quassel-fe-window.o quassel-fe-level.o quassel-cfg.o
 
-CFLAGS=-std=gnu11 -Wall -Wextra -Werror -g -O2 $(IRSSI_CFLAGS) -Wmissing-prototypes -Wmissing-declarations
+LDFLAGS ?=
+
+ifndef SYSTEM_QUASSELC
+    QUASSELC_FLAGS:=-Ilib
+else
+    QUASSELC_FLAGS:=$(shell pkg-config --cflags quasselc)
+    LDFLAGS += -lquasselc
+endif
+
+CFLAGS=-std=gnu11 -Wall -Wextra -Werror -g -O2 $(IRSSI_CFLAGS) $(QUASSELC_FLAGS) -Wmissing-prototypes -Wmissing-declarations
 
 TARGET=libquassel_core.so
 
 all: libquassel_core.so
 
-LIBQUASSEL:=lib/cmds.o lib/display.o lib/io.o
-LIBQUASSEL+=lib/getters.o lib/main.o lib/setters.o
-LIBQUASSEL+=lib/negotiation.o
+ifndef SYSTEM_QUASSELC
+    LIBQUASSEL:=lib/cmds.o lib/display.o lib/io.o
+    LIBQUASSEL+=lib/getters.o lib/main.o lib/setters.o
+    LIBQUASSEL+=lib/negotiation.o
+    OBJECTS += $(LIBQUASSEL)
+endif
 
 irssi/network-openssl.o: CFLAGS:=$(IRSSI_CFLAGS)
-quasselc-connector.o: CFLAGS:=$(CFLAGS) -Ilib
 
-$(TARGET): $(OBJECTS) $(LIBQUASSEL)
-	gcc -shared $^ -o $@ -lz
+quasselc-connector.o: CFLAGS:=$(CFLAGS)
+
+$(TARGET): $(OBJECTS)
+	gcc -shared $^ -o $@ -lz $(LDFLAGS)
 
 install: $(TARGET)
 	$(INSTALL) -d $(IRSSI_LIB)/modules

--- a/core/quassel-irssi.h
+++ b/core/quassel-irssi.h
@@ -1,7 +1,7 @@
 #ifndef QUASSEL_IRSSI_H
 #define QUASSEL_IRSSI_H
 
-#include "lib/export.h"
+#include "export.h"
 
 #define STRUCT_SERVER_CONNECT_REC struct Quassel_SERVER_CONNECT_REC_s 
 typedef struct Quassel_SERVER_CONNECT_REC_s {


### PR DESCRIPTION
This is an adapted version of #10, except it uses the makefile variable SYSTEM_QUASSELC. If SYSTEM_QUASSELC is not set, then quassel-irssi is built and linked against the bundled (via git submodule) copy of libquasselc.

If SYSTEM_QUASSELC is set, then quassel-irssi looks for a system-wide copy of libquasselc and attempts to link against it.

This also amends the build process slightly to respect LDFLAGS (so we can pass -lquasselc when linking when SYSTEM_QUASSELC is set).

There is one quirk, which is that you must set SYSTEM_QUASSELC both when building and installing.

I tested that building and loading from irssi works in both cases.