### PR TITLE
Fix nullpointer dereference when leaving an unconnected window

### DIFF
--- a/core/quassel-fe-level.c
+++ b/core/quassel-fe-level.c
@@ -62,6 +62,10 @@ static void sig_created(WINDOW_REC *winrec, int automatic) {
 		return;
 	}
 
+	if (!winrec->active_server) {
+		return;
+	}
+
 	CHANNEL_REC *_chanrec = channel_find(winrec->active_server, winrec->active->visible_name);
 	if(_chanrec->chat_type != Quassel_PROTOCOL)
 		return;


### PR DESCRIPTION
Easy fix,
winrec->active_server can be null if the windows underlying server is not connected. In that case leaving the window will cause a segfault trying to dereference winrec->active_server via channel_find.

