### PR TITLE
replace ssl by tls where it matters

### DIFF
--- a/core/irssi/network-openssl.c
+++ b/core/irssi/network-openssl.c
@@ -437,11 +437,11 @@ GIOChannel *irssi_ssl_get_iochannel(GIOChannel *handle, int port, SERVER_REC *se
 	SSL *ssl;
 	SSL_CTX *ctx = NULL;
 
-	const char *mycert = server->connrec->ssl_cert;
-	const char *mypkey = server->connrec->ssl_pkey;
-	const char *cafile = server->connrec->ssl_cafile;
-	const char *capath = server->connrec->ssl_capath;
-	gboolean verify = server->connrec->ssl_verify;
+	const char *mycert = server->connrec->tls_cert;
+	const char *mypkey = server->connrec->tls_pkey;
+	const char *cafile = server->connrec->tls_cafile;
+	const char *capath = server->connrec->tls_capath;
+	gboolean verify = server->connrec->tls_verify;
 
 	g_return_val_if_fail(handle != NULL, NULL);
 

--- a/core/quassel-net.c
+++ b/core/quassel-net.c
@@ -132,10 +132,10 @@ static SERVER_REC* quassel_server_init_connect(SERVER_CONNECT_REC* conn) {
 	ret->got = 0;
 	server_connect_ref(SERVER_CONNECT(conn));
 
-	if(conn->use_ssl) {
+	if(conn->use_tls) {
 		ret->ssl = 1;
 	}
-	ret->connrec->use_ssl = 0;
+	ret->connrec->use_tls = 0;
 
 	ret->channels_join = quassel_irssi_channels_join;
 	ret->send_message = quassel_irssi_send_message;


### PR DESCRIPTION
This PR is based on the `gcc7` branch.
It fixes the compilation errors caused by the presence of `use_ssl` and friends.